### PR TITLE
Allow colons in policy name

### DIFF
--- a/minio/resource_minio_iam_policy.go
+++ b/minio/resource_minio_iam_policy.go
@@ -137,9 +137,9 @@ func validateIAMNamePolicy(v interface{}, k string) (ws []string, errors []error
 			"%q cannot be longer than 96 characters, name is limited to 128", k))
 	}
 
-	if !regexp.MustCompile(`^[\w+=,.@-]*$`).MatchString(value) {
+	if !regexp.MustCompile(`^[\w+=,.@-:]*$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must match [\\w+=,.@-]", k))
+			"%q must match [\\w+=,.@-:]", k))
 	}
 	return
 }

--- a/minio/resource_minio_iam_policy.go
+++ b/minio/resource_minio_iam_policy.go
@@ -137,9 +137,9 @@ func validateIAMNamePolicy(v interface{}, k string) (ws []string, errors []error
 			"%q cannot be longer than 96 characters, name is limited to 128", k))
 	}
 
-	if !regexp.MustCompile(`^[\w+=,.@-:]*$`).MatchString(value) {
+	if !regexp.MustCompile(`^[\w+=,.@:-]*$`).MatchString(value) {
 		errors = append(errors, fmt.Errorf(
-			"%q must match [\\w+=,.@-:]", k))
+			"%q must match [\\w+=,.@:-]", k))
 	}
 	return
 }


### PR DESCRIPTION
### Description

Policy names are not allowed to contain a colon (:) in the name. This is allowed by the Minio webinterface and is used by SSO to reference claims.

### Steps to Reproduce
1. Add a policy resource

resource "minio_iam_policy" "test" {
  name = "urn:test:bucketname"
  policy= <<EOF
{
  "Version":"2012-10-17",
  "Statement": [
    {
      "Sid":"ListAllBucket",
      "Effect": "Allow",
      "Action": ["s3:PutObject"],
      "Principal":"*",
      "Resource": "arn:aws:s3:::*/*"
    }
  ]
}
EOF
}
2. Run a terraform plan
3. Results in error:
Error: "name" must match [\w+=,.@-]
│
│   with minio_iam_policy.test,

**Expected behavior:** 
The resource should be created with the use of colons

**Actual behavior:** [What actually happens]
The policy resource is not created, but the error occurs

**Reproduces how often:** [What percentage of the time does it reproduce?]
100%

### Versions

1.17.1

### Additional Information

Minio allows the creation of policies using the colon in the web interface. Not really sure why this limitation has been put in the terraform module.
